### PR TITLE
chore: call docker reusables from catalog ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,6 @@ on:
       - ".devcontainer/**"
 
 env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
   GO_VERSION: "1.25"
 
 permissions:
@@ -53,156 +51,39 @@ jobs:
         run: |
           go mod tidy
           if [ -n "$(git status --porcelain)" ]; then
-            echo "❌ go.mod or go.sum has uncommitted changes"
+            echo "go.mod or go.sum has uncommitted changes"
             git diff
             exit 1
           fi
-          echo "✅ go.mod is clean"
 
       - name: Build binary
         run: go build -v -o bin/catalog-service main.go
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-
-      - name: Validate container build
-        run: |
-          # Test that the container builds successfully
-          docker build -t retail-catalog-service:test .
-          echo "✅ Container builds successfully"
-
-      - name: Validate container health check
-        run: |
-          # Test container health check
-          docker run -d --name test-container retail-catalog-service:test
-
-          # Wait for container to start and health check to become available
-          echo "Waiting for container to start and health check to become available..."
-          for i in {1..60}; do
-            if docker ps --filter "name=test-container" --filter "status=running" --format "{{.Names}}" | grep -q "test-container"; then
-              echo "Container is running, waiting for health check..."
-              sleep 5
-
-              # Check if health check is available
-              HEALTH_STATUS=$(docker inspect test-container --format='{{.State.Health.Status}}' 2>/dev/null || echo "")
-              if [ -n "$HEALTH_STATUS" ]; then
-                echo "Health check is available: $HEALTH_STATUS"
-                # Wait for health check to complete
-                if [ "$HEALTH_STATUS" = "healthy" ]; then
-                  echo "✅ Container health check passed"
-                  break
-                elif [ "$HEALTH_STATUS" = "starting" ]; then
-                  echo "Health check still starting, waiting..."
-                  continue
-                else
-                  echo "Health check status: $HEALTH_STATUS"
-                  break
-                fi
-              fi
-            else
-              echo "Container failed to start"
-              docker logs test-container
-              exit 1
-            fi
-          done
-
-          # Final health check
-          HEALTH_STATUS=$(docker inspect test-container --format='{{.State.Health.Status}}')
-          echo "Final health status: $HEALTH_STATUS"
-
-          if [ "$HEALTH_STATUS" = "healthy" ]; then
-            echo "✅ Container health check passed"
-          else
-            echo "❌ Container health check failed: $HEALTH_STATUS"
-            docker logs test-container
-            exit 1
-          fi
-
-          docker stop test-container
-          docker rm test-container
-          echo "✅ Container validation completed successfully"
-
-      - name: Security scan
-        run: |
-          # Basic security checks
-          echo "🔍 Checking for common security issues..."
-
-          # Check for hardcoded secrets (basic check)
-          if grep -r "password\|secret\|key\|token" . --exclude="*.go" --exclude="*.md" --exclude="*.yml" --exclude="*.yaml" --exclude="*.json" --exclude="*.txt" --exclude="*.log" 2>/dev/null; then
-            echo "⚠️  Potential hardcoded secrets found"
-          fi
-
-          # Check for proper error handling
-          if ! grep -r "if err != nil" . --include="*.go"; then
-            echo "⚠️  Check error handling in code"
-          fi
-
-          echo "✅ Basic security checks completed"
-
-      - name: Validation Summary
-        run: |
-          echo "✅ All validation checks passed!"
-          echo "📦 Binary built successfully"
-          echo "🐳 Container builds and runs"
-          echo "🔒 Security checks completed"
+  validate-image:
+    uses: actionsforge/actions/.github/workflows/docker-image-validate.yml@main
+    with:
+      image-tag: "retail-catalog-service:test"
+      # Match prior CI: prove the image builds; Trivy stays opt-in until the base is hardened.
+      scan-enabled: false
 
   build-and-push:
-    needs: [validate, test, golangci-lint, govulncheck]
-    runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: Set up Go
-        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          cache: true
-
-      - name: Build Go binary
-        run: |
-          go build -v -ldflags="-s -w" -o bin/catalog-service main.go
-          echo "✅ Go binary built successfully"
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-
-      - name: Log in to Container Registry
-        uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4.5.1
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata
-        id: meta
-        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=ref,event=tag
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: Build Summary
-        run: |
-          echo "✅ Build and push completed successfully!"
-          echo "🐳 Docker image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
-          echo "🏷️  Tags: ${{ steps.meta.outputs.tags }}"
+    needs: [validate, validate-image, test, golangci-lint, govulncheck]
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
+    permissions:
+      contents: write
+      packages: write
+    uses: actionsforge/actions/.github/workflows/docker-image-release.yml@main
+    with:
+      # Tag releases still publish Go binaries via the release job below.
+      create-release: false
+    secrets: inherit
 
   release:
-    needs: [validate, test, golangci-lint, govulncheck]
+    needs: [validate, validate-image, test, golangci-lint, govulncheck]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -218,7 +99,6 @@ jobs:
           GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o dist/catalog-service-linux-amd64 main.go
           GOOS=darwin GOARCH=amd64 go build -ldflags="-s -w" -o dist/catalog-service-darwin-amd64 main.go
           GOOS=darwin GOARCH=arm64 go build -ldflags="-s -w" -o dist/catalog-service-darwin-arm64 main.go
-          echo "✅ Release binaries built successfully"
 
       - name: Create Release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
@@ -226,11 +106,6 @@ jobs:
           files: dist/*
           draft: false
           prerelease: false
+          generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Release Summary
-        run: |
-          echo "✅ Release created successfully!"
-          echo "📦 Release binaries available in dist/"
-          echo "🏷️  Tag: ${GITHUB_REF#refs/tags/}"


### PR DESCRIPTION
## Summary
- Use `docker-image-validate` for image build checks (Trivy off for parity with prior CI).
- Use `docker-image-release` for GHCR push on `main` and `v*` tags (`create-release: false`).
- Slim local `validate` to `go mod tidy` + `go build`; keep multi-OS binary GH release job.
- Drop the low-value grep "security scan" and the long health-check loop.

## Test plan
- [ ] PR checks: golangci, govulncheck, go-test, validate, validate-image green
- [ ] Confirm build-and-push / release skipped on PR