### PR TITLE
chore: use go-mod-tidy-build and go-binary-release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,6 @@ on:
       - ".vscode/**"
       - ".devcontainer/**"
 
-env:
-  GO_VERSION: "1.25"
-
 permissions:
   contents: read
   pull-requests: write
@@ -37,27 +34,10 @@ jobs:
       test-pattern: "./..."
 
   validate:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: Set up Go
-        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          cache: true
-
-      - name: Check go mod tidy
-        run: |
-          go mod tidy
-          if [ -n "$(git status --porcelain)" ]; then
-            echo "go.mod or go.sum has uncommitted changes"
-            git diff
-            exit 1
-          fi
-
-      - name: Build binary
-        run: go build -v -o bin/catalog-service main.go
+    uses: actionsforge/actions/.github/workflows/go-mod-tidy-build.yml@main
+    with:
+      go-version: "1.25"
+      build-command: go build -v -o bin/catalog-service main.go
 
   validate-image:
     uses: actionsforge/actions/.github/workflows/docker-image-validate.yml@main
@@ -80,32 +60,12 @@ jobs:
 
   release:
     needs: [validate, validate-image, test, golangci-lint, govulncheck]
-    runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: write
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: Set up Go
-        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          cache: true
-
-      - name: Build release binaries
-        run: |
-          mkdir -p dist
-          GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o dist/catalog-service-linux-amd64 main.go
-          GOOS=darwin GOARCH=amd64 go build -ldflags="-s -w" -o dist/catalog-service-darwin-amd64 main.go
-          GOOS=darwin GOARCH=arm64 go build -ldflags="-s -w" -o dist/catalog-service-darwin-arm64 main.go
-
-      - name: Create Release
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
-        with:
-          files: dist/*
-          draft: false
-          prerelease: false
-          generate_release_notes: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    uses: actionsforge/actions/.github/workflows/go-binary-release.yml@main
+    with:
+      go-version: "1.25"
+      binary-name: catalog-service
+      package: main.go
+    secrets: inherit


### PR DESCRIPTION
## Summary
- Call `actionsforge/actions` `go-mod-tidy-build` for validate.
- Call `go-binary-release` for tagged multi-OS binary assets.
- Depends on actionsforge/actions#124 (merged).

## Test plan
- [ ] PR checks green (validate via reusable, image validate, lint, test)
- [ ] release / build-and-push skipped on PR