### PR TITLE
fix: gate CI on govulncheck and bump grpc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,32 +22,62 @@ permissions:
   packages: write
 
 jobs:
-  golangci-lint:
-    uses: actionsforge/actions-golangci-lint/.github/workflows/golangci-lint.yml@v0
-
+  # Fail fast: do not run the rest of CI when known vulns are present.
   govulncheck:
     uses: actionsforge/actions-govulncheck/.github/workflows/govulncheck.yml@v0
 
+  golangci-lint:
+    needs: [govulncheck]
+    uses: actionsforge/actions-golangci-lint/.github/workflows/golangci-lint.yml@v0
+
   test:
+    needs: [govulncheck]
     uses: actionsforge/actions-go-test/.github/workflows/go-test.yml@v0
     with:
       test-pattern: "./..."
 
   validate:
+    needs: [govulncheck]
     uses: actionsforge/actions/.github/workflows/go-mod-tidy-build.yml@main
     with:
       go-version: "1.25"
       build-command: go build -v -o bin/catalog-service main.go
 
   validate-image:
+    needs: [govulncheck]
     uses: actionsforge/actions/.github/workflows/docker-image-validate.yml@main
     with:
       image-tag: "retail-catalog-service:test"
       # Match prior CI: prove the image builds; Trivy stays opt-in until the base is hardened.
       scan-enabled: false
 
+  # Single required status for branch protection / auto-merge.
+  ci:
+    name: CI
+    needs: [govulncheck, golangci-lint, test, validate, validate-image]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require all checks to pass
+        run: |
+          set -euo pipefail
+          results=(
+            "${{ needs.govulncheck.result }}"
+            "${{ needs.golangci-lint.result }}"
+            "${{ needs.test.result }}"
+            "${{ needs.validate.result }}"
+            "${{ needs.validate-image.result }}"
+          )
+          for r in "${results[@]}"; do
+            if [ "$r" != "success" ]; then
+              echo "One or more required jobs did not succeed: ${results[*]}"
+              exit 1
+            fi
+          done
+          echo "All required CI jobs succeeded"
+
   build-and-push:
-    needs: [validate, validate-image, test, golangci-lint, govulncheck]
+    needs: [ci]
     if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
     permissions:
       contents: write
@@ -59,7 +89,7 @@ jobs:
     secrets: inherit
 
   release:
-    needs: [validate, validate-image, test, golangci-lint, govulncheck]
+    needs: [ci]
     if: startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: write

--- a/go.mod
+++ b/go.mod
@@ -117,7 +117,7 @@ require (
 	golang.org/x/sync v0.21.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
-	google.golang.org/grpc v1.81.1 // indirect
+	google.golang.org/grpc v1.82.1 // indirect
 	gorm.io/driver/clickhouse v0.7.0 // indirect
 	gorm.io/driver/postgres v1.5.11 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -317,8 +317,8 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:q4lMZS6kskjT5HvCPrnnypcDPVJqT/f4nfxmkE7gryY=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa h1:mZHHdPZl0dbGHCflZgAq/Q468DWVFcU2whhB2KAo8fk=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.81.1 h1:VnnIIZ88UzOOKLukQi+ImGz8O1Wdp8nAGGnvOfEIWQQ=
-google.golang.org/grpc v1.81.1/go.mod h1:xGH9GfzOyMTGIOXBJmXt+BX/V0kcdQbdcuwQ/zNw42I=
+google.golang.org/grpc v1.82.1 h1:NnAxzGRA0677vCa4BUkOAnO5+FfQqVl9iUXeD0IqcGE=
+google.golang.org/grpc v1.82.1/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
## Summary
- After Dependabot merges, main CI failed on `govulncheck` (`GO-2026-6061` in `google.golang.org/grpc@v1.81.1`) while other jobs kept running
- Run lint/test/validate/image only after `govulncheck` succeeds
- Add a single `CI` aggregate job; release/publish need it
- Bump `google.golang.org/grpc` to `v1.82.1`

Closes #42

## Test plan
- [ ] PR CI: `govulncheck` green, then other jobs, `CI` green
- [ ] Confirm branch protection requires `CI` before merge